### PR TITLE
Parse `watch-extensions` and `compiler` options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,13 @@ function findMocha(done) {
     found(bin.mocha);
   });
 }
-function globberFactory(recursive) {
+function globberFactory(recursive, extensions) {
+  var filePattern;
+  if (extensions.length > 1) {
+    filePattern = '*.+(' + extensions.join('|') + ')';
+  } else {
+    filePattern = '*.' + extensions[0];
+  }
   return function globber(paths, done) {
     function dirToGlob(filepath, callback) {
       fs.stat(filepath, function(err, stat) {
@@ -43,7 +49,7 @@ function globberFactory(recursive) {
         }
         if (stat.isDirectory()) {
           return callback(null, path.join(filepath, recursive ?
-            path.join('**', '*.js') : '*.js'));
+            path.join('**', filePattern) : filePattern));
         }
         return callback(null, filepath);
       });


### PR DESCRIPTION
Uses it to customise watch pattern.

For example,

```
$ mowatch --compilers ts:ts-node/register --recursive src
Watching src/**/*.+(js|ts)
```
